### PR TITLE
Groundwork for Create Player

### DIFF
--- a/mox/__init__.py
+++ b/mox/__init__.py
@@ -1,0 +1,33 @@
+import os
+
+from flask import Flask
+
+
+def create_app(test_config=None):
+    app = Flask(__name__, instance_relative_config=True)
+    __configure_app(app, test_config)
+    __register_routes(app)
+    __create_app_folder(app)
+    return app
+
+
+def __configure_app(app, test_config):
+    app.config['SECRET_KEY'] = 'dev'
+    app.config['DATABASE'] = os.path.join(app.instance_path, 'flask.sqlite')
+
+    if test_config is None:
+        app.config.from_pyfile('config.py', silent=True)
+    else:
+        app.config.from_mapping(test_config)
+
+
+def __register_routes(app):
+    from mox.controllers import players_controller
+    app.register_blueprint(players_controller.blueprint)
+
+
+def __create_app_folder(app):
+    try:
+        os.makedirs(app.instance_path)
+    except OSError:
+        pass

--- a/mox/controllers/players_controller.py
+++ b/mox/controllers/players_controller.py
@@ -6,5 +6,5 @@ blueprint = Blueprint('players', __name__)
 
 @blueprint.route('/players', methods=('POST',))
 def create():
-    player = Player.create(request.form)
+    player = Player.create(request.json)
     return make_response(jsonify(player.serialize()), 201)

--- a/mox/controllers/players_controller.py
+++ b/mox/controllers/players_controller.py
@@ -1,0 +1,8 @@
+from flask import Blueprint, request
+
+blueprint = Blueprint('players', __name__)
+
+
+@blueprint.route('/players', methods=('POST',))
+def create():
+    return '', 201

--- a/mox/controllers/players_controller.py
+++ b/mox/controllers/players_controller.py
@@ -1,8 +1,9 @@
-from flask import Blueprint, request
+from flask import Blueprint, request, make_response, jsonify
 
 blueprint = Blueprint('players', __name__)
 
 
 @blueprint.route('/players', methods=('POST',))
 def create():
-    return '', 201
+    data = request.form
+    return make_response(jsonify(data), 201)

--- a/mox/controllers/players_controller.py
+++ b/mox/controllers/players_controller.py
@@ -1,3 +1,4 @@
+from mox.models import Player
 from flask import Blueprint, request, make_response, jsonify
 
 blueprint = Blueprint('players', __name__)
@@ -5,5 +6,5 @@ blueprint = Blueprint('players', __name__)
 
 @blueprint.route('/players', methods=('POST',))
 def create():
-    data = request.form
-    return make_response(jsonify(data), 201)
+    player = Player.create(request.form)
+    return make_response(jsonify(player.serialize()), 201)

--- a/mox/models/__init__.py
+++ b/mox/models/__init__.py
@@ -1,0 +1,1 @@
+from .player import Player

--- a/mox/models/player.py
+++ b/mox/models/player.py
@@ -1,0 +1,17 @@
+class Player:
+    def __init__(self, firstname, lastname):
+        self.firstname = firstname
+        self.lastname = lastname
+
+    @staticmethod
+    def create(attributes):
+        return Player(
+            firstname=attributes['firstname'],
+            lastname=attributes['lastname']
+        )
+
+    def serialize(self):
+        return {
+            'firstname': self.firstname,
+            'lastname': self.lastname
+        }

--- a/tests/client.py
+++ b/tests/client.py
@@ -1,0 +1,21 @@
+import os
+import tempfile
+import pytest
+
+from mox import create_app
+
+
+@pytest.fixture
+def client():
+    db_fd, database_config = tempfile.mkstemp()
+
+    app = create_app({
+        'DATABASE': database_config,
+        'TESTING': True
+    })
+
+    yield app.test_client()
+
+    os.close(db_fd)
+    os.unlink(app.config['DATABASE'])
+

--- a/tests/integration/test_player.py
+++ b/tests/integration/test_player.py
@@ -1,0 +1,9 @@
+import pytest
+
+from tests.client import client
+
+
+def test_create(client):
+    data = { 'firstname': 'Binom', 'lastname': 'Missieux' }
+    response = client.post('/players', data=data)
+    assert response.status_code == 201

--- a/tests/integration/test_player.py
+++ b/tests/integration/test_player.py
@@ -6,4 +6,6 @@ from tests.client import client
 def test_create(client):
     data = { 'firstname': 'Binom', 'lastname': 'Missieux' }
     response = client.post('/players', data=data)
+
     assert response.status_code == 201
+    assert response.data == b'{"firstname":"Binom","lastname":"Missieux"}\n'

--- a/tests/integration/test_players.py
+++ b/tests/integration/test_players.py
@@ -1,11 +1,12 @@
 import pytest
+import json
 
 from tests.client import client
 
 
 def test_create(client):
     data = { 'firstname': 'Binom', 'lastname': 'Missieu' }
-    response = client.post('/players', data=data)
+    response = client.post('/players', data=json.dumps(data), content_type='application/json')
 
     assert response.status_code == 201
     assert response.data == b'{"firstname":"Binom","lastname":"Missieu"}\n'

--- a/tests/integration/test_players.py
+++ b/tests/integration/test_players.py
@@ -4,8 +4,8 @@ from tests.client import client
 
 
 def test_create(client):
-    data = { 'firstname': 'Binom', 'lastname': 'Missieux' }
+    data = { 'firstname': 'Binom', 'lastname': 'Missieu' }
     response = client.post('/players', data=data)
 
     assert response.status_code == 201
-    assert response.data == b'{"firstname":"Binom","lastname":"Missieux"}\n'
+    assert response.data == b'{"firstname":"Binom","lastname":"Missieu"}\n'

--- a/tests/unit/test_player.py
+++ b/tests/unit/test_player.py
@@ -6,4 +6,6 @@ from mox.models import Player
 def test_create():
     attributes = { 'firstname': 'Binom', 'lastname': 'Missieu' }
     player = Player.create(attributes)
+
     assert player.firstname == 'Binom'
+    assert player.lastname == 'Missieu'

--- a/tests/unit/test_player.py
+++ b/tests/unit/test_player.py
@@ -1,0 +1,9 @@
+import pytest
+
+from mox.models import Player
+
+
+def test_create():
+    attributes = { 'firstname': 'Binom', 'lastname': 'Missieu' }
+    player = Player.create(attributes)
+    assert player.firstname == 'Binom'


### PR DESCRIPTION
**What's New?**
Implement a sample dumb endpoint to create players. Currently, it's just returning the sent firstname/lastname but in the near future it will persist the player in the database.

**Ticket**
#11 