### PR TITLE
Persist Players in Database

### DIFF
--- a/mox/__init__.py
+++ b/mox/__init__.py
@@ -1,19 +1,26 @@
 import os
 
 from flask import Flask
+from mox.data import Database
+from mox.controllers import PlayersController, tournaments_controller
 
 
-def create_app(config):
+class Dependencies:
+    def __init__(self, config):
+        self.config = config
+        self.database = Database(config)
+
+
+def create_app(deps):
     app = Flask(__name__, instance_relative_config=True)
-    app.config.from_object(config)
-    __register_routes(app)
+    app.config.from_object(deps.config)
+    __register_routes(app, deps)
     __create_app_folder(app)
     return app
 
 
-def __register_routes(app):
-    from mox.controllers import players_controller, tournaments_controller
-    app.register_blueprint(players_controller.blueprint)
+def __register_routes(app, deps):
+    PlayersController(deps.database).register(app)
     app.register_blueprint(tournaments_controller.blueprint)
 
 

--- a/mox/__init__.py
+++ b/mox/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from flask import Flask
 from mox.data import Database
-from mox.controllers import PlayersController, tournaments_controller
+from mox.controllers import PlayersController, TournamentsController
 
 
 class Dependencies:
@@ -21,7 +21,7 @@ def create_app(deps):
 
 def __register_routes(app, deps):
     PlayersController(deps.database).register(app)
-    app.register_blueprint(tournaments_controller.blueprint)
+    TournamentsController(deps.database).register(app)
 
 
 def __create_app_folder(app):

--- a/mox/controllers/__init__.py
+++ b/mox/controllers/__init__.py
@@ -1,0 +1,1 @@
+from .players_controller import PlayersController

--- a/mox/controllers/__init__.py
+++ b/mox/controllers/__init__.py
@@ -1,1 +1,2 @@
 from .players_controller import PlayersController
+from .tournaments_controller import TournamentsController

--- a/mox/controllers/controller.py
+++ b/mox/controllers/controller.py
@@ -2,11 +2,16 @@ from flask import Blueprint, request, make_response, jsonify
 
 
 class Controller:
+    @property
+    def resource_name(self):
+        class_name = self.__class__.__name__
+        return class_name[:-len('Controller')].lower()
+
     def register(self, app):
-        bp = Blueprint(self.resource, __name__)
+        bp = Blueprint(self.resource_name, __name__)
 
         if hasattr(self, 'create'):
-            @bp.route(f'/{self.resource}', methods=('POST',))
+            @bp.route(f'/{self.resource_name}', methods=('POST',))
             def create():
                 return self.create(request)
 

--- a/mox/controllers/controller.py
+++ b/mox/controllers/controller.py
@@ -1,0 +1,16 @@
+from flask import Blueprint, request, make_response, jsonify
+
+
+class Controller:
+    def register(self, app):
+        bp = Blueprint(self.resource, __name__)
+
+        if hasattr(self, 'create'):
+            @bp.route(f'/{self.resource}', methods=('POST',))
+            def create():
+                return self.create(request)
+
+        app.register_blueprint(bp)
+
+    def response(self, body, status):
+        return make_response(jsonify(body), status)

--- a/mox/controllers/players_controller.py
+++ b/mox/controllers/players_controller.py
@@ -3,8 +3,6 @@ from .controller import Controller
 
 
 class PlayersController(Controller):
-    resource = 'players'
-
     def __init__(self, database):
         self.repo = PlayerRepository(database)
 

--- a/mox/controllers/players_controller.py
+++ b/mox/controllers/players_controller.py
@@ -1,10 +1,13 @@
 from mox.models import Player
-from flask import Blueprint, request, make_response, jsonify
-
-blueprint = Blueprint('players', __name__)
+from .controller import Controller
 
 
-@blueprint.route('/players', methods=('POST',))
-def create():
-    player = Player.create(request.json)
-    return make_response(jsonify(player.serialize()), 201)
+class PlayersController(Controller):
+    resource = 'players'
+
+    def __init__(self, database):
+        self.database = database
+
+    def create(self, request):
+        player = Player.create(request.json)
+        return self.response(player.serialize(), 201)

--- a/mox/controllers/players_controller.py
+++ b/mox/controllers/players_controller.py
@@ -1,4 +1,4 @@
-from mox.models import Player
+from mox.data import PlayerRepository
 from .controller import Controller
 
 
@@ -6,8 +6,8 @@ class PlayersController(Controller):
     resource = 'players'
 
     def __init__(self, database):
-        self.database = database
+        self.repo = PlayerRepository(database)
 
     def create(self, request):
-        player = Player.create(request.json)
+        player = self.repo.create(request.json)
         return self.response(player.serialize(), 201)

--- a/mox/controllers/tournaments_controller.py
+++ b/mox/controllers/tournaments_controller.py
@@ -3,8 +3,6 @@ from .controller import Controller
 
 
 class TournamentsController(Controller):
-    resource = 'tournaments'
-
     def __init__(self, database):
         self.database = database
 

--- a/mox/controllers/tournaments_controller.py
+++ b/mox/controllers/tournaments_controller.py
@@ -1,10 +1,13 @@
 from mox.models import Tournament
-from flask import Blueprint, request, make_response, jsonify
-
-blueprint = Blueprint('tournaments', __name__)
+from .controller import Controller
 
 
-@blueprint.route('/tournaments', methods=('POST',))
-def create():
-    tournament = Tournament.create(request.json)
-    return make_response(jsonify(tournament.serialize()), 201)
+class TournamentsController(Controller):
+    resource = 'tournaments'
+
+    def __init__(self, database):
+        self.database = database
+
+    def create(self, request):
+        tournament = Tournament.create(request.json)
+        return self.response(tournament.serialize(), 201)

--- a/mox/data/__init__.py
+++ b/mox/data/__init__.py
@@ -3,3 +3,4 @@ from .migrator import Migrator
 from .migration import Migration
 from .schema import Schema
 from .migration_logger import MigrationLogger
+from .player_repository import PlayerRepository

--- a/mox/data/database.py
+++ b/mox/data/database.py
@@ -17,7 +17,7 @@ class Database:
 
     def close(self):
         if not hasattr(self, 'connection'):
-            raise ValueError('No connection to close. Did you run open()?')
+            pass
         else:
             self.connection.commit()
             self.cursor.close()
@@ -25,18 +25,18 @@ class Database:
 
     def execute(self, sql, values=None):
         if not hasattr(self, 'connection'):
-            raise ValueError('No connection available. Did you run open()?')
-        else:
-            self.cursor.execute(sql, values)
+            self.open()
 
-            if self.__records_are_available:
-                return self.cursor.fetchall()
-            else:
-                return True
+        self.cursor.execute(sql, values)
+
+        if self.__records_are_available:
+            return self.cursor.fetchall()
+        else:
+            return True
 
     def rollback(self):
         if not hasattr(self, 'connection'):
-            raise ValueError('No connection available. Did you run open()?')
+            pass
         else:
             self.connection.rollback()
 

--- a/mox/data/player_repository.py
+++ b/mox/data/player_repository.py
@@ -1,0 +1,21 @@
+from mox.models import Player
+
+
+class PlayerRepository:
+    __TABLE_NAME = 'players'
+
+    def __init__(self, database):
+        self.database = database
+
+    def create(self, attributes):
+        sql = f'INSERT INTO {self.__TABLE_NAME} (firstname, lastname) VALUES (%s, %s) RETURNING id;'
+        values = (attributes['firstname'], attributes['lastname'])
+        result = self.database.execute(sql, values)
+        return self.__create_instance(result[0]['id'], attributes)
+
+    def __create_instance(self, id, attributes):
+        return Player(
+            id=id,
+            firstname=attributes['firstname'],
+            lastname=attributes['lastname']
+        )

--- a/mox/models/player.py
+++ b/mox/models/player.py
@@ -1,14 +1,8 @@
 class Player:
-    def __init__(self, firstname, lastname):
+    def __init__(self, id, firstname, lastname):
+        self.id = id
         self.firstname = firstname
         self.lastname = lastname
-
-    @staticmethod
-    def create(attributes):
-        return Player(
-            firstname=attributes['firstname'],
-            lastname=attributes['lastname']
-        )
 
     def serialize(self):
         return {

--- a/mox/models/player.py
+++ b/mox/models/player.py
@@ -6,6 +6,7 @@ class Player:
 
     def serialize(self):
         return {
+            'id': self.id,
             'firstname': self.firstname,
             'lastname': self.lastname
         }

--- a/run.py
+++ b/run.py
@@ -1,6 +1,6 @@
-from mox import create_app
+from mox import create_app, Dependencies
 from config import DevelopmentConfig
 
-
 config = DevelopmentConfig()
-app = create_app(config)
+deps = Dependencies(config)
+app = create_app(deps)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -7,10 +7,17 @@ from config import TestConfig
 
 @pytest.fixture
 def client():
-    from mox import create_app
+    from mox import create_app, Dependencies
+
     config = TestConfig()
-    app = create_app(config)
-    yield app.test_client()
+    deps = Dependencies(config)
+    client = create_app(deps).test_client()
+    client.database = deps.database
+
+    yield client
+
+    deps.database.rollback()
+    deps.database.close()
 
 
 @pytest.fixture

--- a/tests/integration/test_players.py
+++ b/tests/integration/test_players.py
@@ -6,9 +6,12 @@ from tests.fixtures import client
 def test_create(client):
     data = {'firstname': 'Binom', 'lastname': 'Missieu'}
 
-    response = client.post('/players',
-                           data=json.dumps(data),
-                           content_type='application/json')
+    response = client.post('/players', data=json.dumps(data), content_type='application/json')
+    player_id = client.database.execute('SELECT (id) FROM players;')[0]['id']
 
     assert response.status_code == 201
-    assert response.data == b'{"firstname":"Binom","lastname":"Missieu"}\n'
+    assert json.loads(response.data) == {
+        "id": player_id,
+        "firstname": "Binom",
+        "lastname": "Missieu"
+    }

--- a/tests/integration/test_players.py
+++ b/tests/integration/test_players.py
@@ -1,4 +1,3 @@
-import pytest
 import json
 
 from tests.fixtures import client

--- a/tests/integration/test_tournaments.py
+++ b/tests/integration/test_tournaments.py
@@ -1,4 +1,3 @@
-import pytest
 import json
 
 from tests.fixtures import client

--- a/tests/unit/controllers/test_controller.py
+++ b/tests/unit/controllers/test_controller.py
@@ -1,0 +1,10 @@
+from mox.controllers.controller import Controller
+
+
+def test_resource_name():
+    class MonkeysController(Controller):
+        pass
+
+    controller = MonkeysController()
+
+    assert controller.resource_name == 'monkeys'

--- a/tests/unit/data/test_database.py
+++ b/tests/unit/data/test_database.py
@@ -1,5 +1,3 @@
-import pytest
-
 from mox.data import Database
 from config import TestConfig
 from tests.fixtures import database

--- a/tests/unit/data/test_migration.py
+++ b/tests/unit/data/test_migration.py
@@ -1,5 +1,3 @@
-import pytest
-
 from mox.data import Migration
 from pathlib import Path
 

--- a/tests/unit/data/test_migration_logger.py
+++ b/tests/unit/data/test_migration_logger.py
@@ -1,5 +1,3 @@
-import pytest
-
 from config import DevelopmentConfig
 from pathlib import Path
 from mox.data import MigrationLogger, Migration

--- a/tests/unit/data/test_migrator.py
+++ b/tests/unit/data/test_migrator.py
@@ -1,5 +1,3 @@
-import pytest
-
 from mox.data import Migrator, Migration, Schema
 from tests.fixtures import database
 from tests.decorators import with_clean_schema_version

--- a/tests/unit/data/test_player_repository.py
+++ b/tests/unit/data/test_player_repository.py
@@ -1,0 +1,25 @@
+import pytest
+
+from mox.data import PlayerRepository
+from tests.fixtures import database
+
+
+attributes = {'firstname': 'Richard', 'lastname': 'Garfield'}
+
+
+def test_create_returns_player(database):
+    repo = PlayerRepository(database)
+    player = repo.create(attributes)
+
+    assert player.id is not None
+    assert player.firstname == 'Richard'
+    assert player.lastname == 'Garfield'
+
+
+def test_create_persist_player(database):
+    repo = PlayerRepository(database)
+    repo.create(attributes)
+    result = database.execute('SELECT * FROM players;')[0]
+
+    assert result['firstname'] == 'Richard'
+    assert result['lastname'] == 'Garfield'

--- a/tests/unit/data/test_player_repository.py
+++ b/tests/unit/data/test_player_repository.py
@@ -1,5 +1,3 @@
-import pytest
-
 from mox.data import PlayerRepository
 from tests.fixtures import database
 

--- a/tests/unit/data/test_schema.py
+++ b/tests/unit/data/test_schema.py
@@ -1,5 +1,3 @@
-import pytest
-
 from tests.fixtures import database
 from tests.decorators import with_clean_schema_version
 from mox.data import Schema

--- a/tests/unit/models/test_player.py
+++ b/tests/unit/models/test_player.py
@@ -1,11 +1,3 @@
 import pytest
 
 from mox.models import Player
-
-
-def test_create():
-    attributes = {'firstname': 'Binom', 'lastname': 'Missieu'}
-    player = Player.create(attributes)
-
-    assert player.firstname == 'Binom'
-    assert player.lastname == 'Missieu'

--- a/tests/unit/models/test_player.py
+++ b/tests/unit/models/test_player.py
@@ -1,3 +1,0 @@
-import pytest
-
-from mox.models import Player

--- a/tests/unit/models/test_tournament.py
+++ b/tests/unit/models/test_tournament.py
@@ -1,5 +1,3 @@
-import pytest
-
 from mox.models import Tournament
 
 


### PR DESCRIPTION
**What's New?**
- Now that we have a `players` table we persist the player in the database on POST requests.
- Use classes for our controllers to allow simple dependency injection. Right now we're only injecting the database in our controllers.
